### PR TITLE
Fix grunt-browserify dev dependency; 2.x led to 2.0.x branch being...

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "browserify": "4.x",
     "grunt": "0.4.x",
-    "grunt-browserify": "2.x",
+    "grunt-browserify": "2.1.x",
     "grunt-contrib-jshint": "0.10.x",
     "grunt-contrib-uglify": "0.4.x",
     "grunt-nsp-package": "0.0.x",


### PR DESCRIPTION
... installed, which is not compatible with grunt 4.x, and caused a peer dependency violation. Explicitly installing 2.1.x instead fixes this problem, as 2.1.0 introduced grunt 4.x support.
