### PR TITLE
add talky datachannel description using a proprietary namespace

### DIFF
--- a/lib/plugins/jingle.js
+++ b/lib/plugins/jingle.js
@@ -6,6 +6,7 @@ require('../stanza/jingle');
 require('../stanza/rtp');
 require('../stanza/iceUdp');
 require('../stanza/file');
+require('../stanza/datachannel');
 
 
 module.exports = function (client) {

--- a/lib/stanza/datachannel.js
+++ b/lib/stanza/datachannel.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var stanza = require('jxt');
+var jingle = require('./jingle');
+
+
+var NS = 'http://talky.io/ns/datachannel';
+
+
+exports.DataChannel = stanza.define({
+    name: '_datachannel',
+    namespace: NS,
+    element: 'description',
+    fields: {
+        descType: {value: 'datachannel'},
+    }
+});
+
+stanza.extend(jingle.Content, exports.DataChannel);

--- a/lib/stanza/jingle.js
+++ b/lib/stanza/jingle.js
@@ -42,7 +42,7 @@ exports.Content = stanza.define({
         senders: stanza.attribute('senders', 'both'),
         description: {
             get: function () {
-                var opts = ['_rtp', '_filetransfer'];
+                var opts = ['_rtp', '_filetransfer', '_datachannel'];
                 for (var i = 0; i < opts.length; i++) {
                     if (this._extensions[opts[i]]) {
                         return this._extensions[opts[i]];


### PR DESCRIPTION
we should provide an extension mechanism in jingle.js so we can register the _datachannel thing.
