### PR TITLE
BOSH transport: removed catch all block

### DIFF
--- a/lib/transports/bosh.js
+++ b/lib/transports/bosh.js
@@ -217,13 +217,6 @@ BOSHConnection.prototype.request = function (bosh) {
         });
         self.emit('stream:error', serr, err);
         self.disconnect();
-    }).catch(function (err) {
-        var serr = new StreamError({
-            condition: 'undefined-condition'
-        });
-        self.emit('stream:error', serr, err);
-        self.send(serr);
-        self.disconnect();
     }).finally(function () {
         self.requests = _.filter(self.requests, function (item) {
             return item.id !== ticket.id;


### PR DESCRIPTION
Removed catch all block. See https://github.com/otalk/stanza.io/issues/59
