### PR TITLE
Don't load transports, until they are used.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -73,11 +73,6 @@ function Client(opts) {
 
     this.transports = {};
 
-    this.use(require('./plugins/websocket'));
-    this.use(require('./plugins/oldwebsocket'));
-    this.use(require('./plugins/bosh'));
-
-
     this.on('stream:data', function (data) {
         var json = data.toJSON();
 
@@ -315,27 +310,25 @@ Client.prototype.connect = function (opts, transInfo) {
     var self = this;
 
     this._initConfig(opts);
+    
+    if (!transInfo && self.config.transports.length === 1) {
+      transInfo = {};
+      transInfo.name = self.config.transports[0];
+    }
 
-    if (transInfo && transInfo.name && transInfo.url) {
+    if (transInfo && transInfo.name) {
+        if (transInfo.name === 'websocket' || transInfo.name === 'old-websocket') {
+            this.use(require('./plugins/websocket'));
+            this.use(require('./plugins/oldwebsocket'));
+        }
+        if (transInfo.name === 'bosh') {
+            this.use(require('./plugins/bosh'));
+        }
         var trans = self.transport = new self.transports[transInfo.name](self.sm, self.stanzas);
         trans.on('*', function (event, data) {
             self.emit(event, data);
         });
         return trans.connect(self.config);
-    }
-
-    if (!transInfo && self.config.transports.length === 1) {
-        transInfo = {};
-        transInfo.name = self.config.transports[0];
-        if (transInfo.name === 'websocket' || transInfo.name === 'old-websocket') {
-            transInfo.url = self.config.wsURL;
-        }
-        if (transInfo.name === 'bosh') {
-            transInfo.url = self.config.boshURL;
-        }
-        if (transInfo.name && transInfo.url) {
-            return self.connect(null, transInfo);
-        }
     }
 
     return self.discoverBindings(self.config.server, function (err, endpoints) {


### PR DESCRIPTION
I'm working on a solution for react-native, and for that I am build my "own" transport plugin. It would make my life a lot easier if the other transports isn't loaded, when I'm using mine.
Also:
- `transInfo.url` was never used.

This PR does not require any tests, as these changes were regarding connect, and that already has integration-test (still passing).
