### PR TITLE
Fixed duplicate SASL callback response after reconnect

### DIFF
--- a/lib/plugins/sasl.js
+++ b/lib/plugins/sasl.js
@@ -89,5 +89,6 @@ module.exports = function (client, stanzas) {
 
     client.on('disconnected', function () {
         client.features.negotiated.sasl = false;
+        client.releaseGroup('sasl');
     });
 };


### PR DESCRIPTION
Consider the following scenario:

1) The client connects to the server.
2) The server advertises 'sasl' feature with SCRAM-SHA-1 mechanism.
3) The client calls custom `self.getCredentials()` callback (which shows a user prompt).
4) User never provides any credentials.
5) The client is disconnected by the server by timeout.
6) (The same) client reconnects to the server.
7) `client.getCredentials()` is called again, showing the user prompt again.
8) User finally provides the credentials in reasonable time (which are then stored, passed to the callback and also returned immediately in subsequent `client.getCredentials()` runs).

#### What happens now

9) The client sends `sasl:auth`, receives `sasl:challenge` and replies with a **double** `sasl:response` with different nonces.
10) The server closes the connection with `<bad-protocol/>`.

#### What is expected

9) The client sends `sasl:auth`, receives `sasl:challenge` and replies with a single `sasl:response`.
10) The server authenticates the client.

#### Workaround and Pull Request

The problem could be fixed by running `self.releaseGroup('sasl')` in `disconnected` event handler (see below). I believe `sasl` plugin must do that automatically.

#### Code example

```javascript
var client = XMPP.createClient({
	server: 'myserver'
	// no credentials passed!
});

var counter = 0;

client.getCredentials = function(cb) {
	if (client.config.credentials) {
		return cb(null, client.config.redentials);
	}
	counter++;
	if (counter == 1) {
		// Emulate user entering his password for very long time
		// and never calling the callback.
		// The server will disconnect us by timeout.
		return;
	} else {
		// On second attempt, provide login/pass in a short time.
		// This will generate DOUBLE sasl:response from stanza.io
		// and the server will disconnect with <bad-protocol/>
		window.setTimeout(function() {
			client.config.credentials = {username: 'user', password: 'pass'};
			cb(null, client.config.credentials);
		}, 3000);
	}
};

client.on('disconnected', function() {
	// reconnect on disconnect
	setTimeout(function() {
		client.connect();
	}, 1000);
	
	// uncomment to prevent the double sasl:response
	// client.releaseGroup('sasl');
});
```