### PR TITLE
Ensure websocket exists before trying to close it

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -132,7 +132,7 @@ WSConnection.prototype.disconnect = function () {
     } else {
         this.hasStream = false;
         this.stream = undefined;
-        if (this.conn.readyState === WS_OPEN) {
+        if (this.conn && this.conn.readyState === WS_OPEN) {
             this.conn.close();
         }
         this.conn = undefined;


### PR DESCRIPTION
I'm seeing intermittent errors in the console because we are trying to close a websocket that doesn't exist.