### PR TITLE
Bosh - prevent race condition from happening

### DIFF
--- a/lib/transports/bosh.js
+++ b/lib/transports/bosh.js
@@ -83,6 +83,11 @@ function BOSHConnection(sm, stanzas) {
     self.requests = [];
     self.maxRequests = undefined;
     self.sid = '';
+    self.authenticated = false;
+
+    self.on('auth:success', function() {
+        self.authenticated = true;
+    });
 
     self.on('raw:incoming', function (data) {
         data = data.trim();
@@ -261,7 +266,8 @@ BOSHConnection.prototype.request = function (bosh) {
         self.requests = filter(self.requests, function (item) {
             return item.id !== ticket.id;
         });
-        if (bosh.type !== 'terminate' && !self.requests.length) {
+        // do not (re)start long polling if terminating, or request is pending, or before authentication
+        if (bosh.type !== 'terminate' && !self.requests.length && self.authenticated) {
             // Delay next auto-request by two ticks since we're likely
             // to send data anyway next tick.
             process.nextTick(function () {


### PR DESCRIPTION
attempt to fix bosh connexion to ejabberd with stanza.io

According to [XEP-026](http://xmpp.org/extensions/xep-0206.html)

> Upon receiving the <success/> element, the client MUST then ask the connection manager to restart the stream by sending a "restart request"

Unfortunately an empty request is sent after authentication but before xmpp:restart, because of a race condition. Checking if authenticated before sending a new request, prevents race condition from occurring.

related to legastero/stanza.io#186