### PR TITLE
xep-0215: use urls syntax

### DIFF
--- a/lib/plugins/jingle.js
+++ b/lib/plugins/jingle.js
@@ -64,19 +64,19 @@ module.exports = function (client) {
                 var service = services[i];
                 var ice = {};
                 if (service.type === 'stun' || service.type === 'stuns') {
-                    ice.url = service.type + ':' + service.host;
+                    ice.urls = service.type + ':' + service.host;
                     if (service.port) {
-                        ice.url += ':' + service.port;
+                        ice.urls += ':' + service.port;
                     }
                     discovered.push(ice);
                     client.jingle.addICEServer(ice);
                 } else if (service.type === 'turn' || service.type === 'turns') {
-                    ice.url = service.type + ':' + service.host;
+                    ice.urls = service.type + ':' + service.host;
                     if (service.port) {
-                        ice.url += ':' + service.port;
+                        ice.urls += ':' + service.port;
                     }
                     if (service.transport && service.transport !== 'udp') {
-                        ice.url += '?transport=' + service.transport;
+                        ice.urls += '?transport=' + service.transport;
                     }
 
                     if (service.username) {


### PR DESCRIPTION
uses the newer .urls syntax for stun and turn servers.
Yes, it can be a string instead of an array!