### PR TITLE
Fix client.getRoster to use as Promise func

### DIFF
--- a/lib/plugins/roster.js
+++ b/lib/plugins/roster.js
@@ -27,7 +27,6 @@ module.exports = function (client) {
 
     client.getRoster = function (cb) {
         var self = this;
-        cb = cb || function () {};
 
         return client.sendIq({
             type: 'get',


### PR DESCRIPTION
Default value for `cb` prevented Promise.catch, so even if there was an error it still goes into Promise.then with undefined, and as there are if statements to check if callback was provided it will not crash and promise will eat `throw err` for users that didn't process the result.