### PR TITLE
Fix typo in support xeps list

### DIFF
--- a/docs/Supported_XEPs.md
+++ b/docs/Supported_XEPs.md
@@ -93,5 +93,5 @@
 - [XEP-0339: Source-Specific Media Attributes in Jingle](http://xmpp.org/extensions/xep-0339.html)
 - [XEP-0343: Use of DTLS/SCTP in Jingle ICE-UDP](http://xmpp.org/extensions/xep-0343.html)
 - [XEP-0352: Client State Indication](http://xmpp.org/extensions/xep-0352.html)
-- [XEP-0352: References](http://xmpp.org/extensions/xep-0372.html)
+- [XEP-0372: References](http://xmpp.org/extensions/xep-0372.html)
 


### PR DESCRIPTION
References xep was listed as 352 instead of 372.