### PR TITLE
Added RSM max default value in pubsub when retrieving nodes.

### DIFF
--- a/lib/plugins/pubsub.js
+++ b/lib/plugins/pubsub.js
@@ -107,6 +107,9 @@ module.exports = function (client) {
     client.getItems = function (jid, node, opts, cb) {
         opts = opts || {};
         opts.node = node;
+        if(!opts.rsm){
+            opts.rsm = {max:50};
+        }
         return this.sendIq({
             type: 'get',
             to: jid,


### PR DESCRIPTION
For Compatibility with ejabberd prior to [this](https://github.com/processone/ejabberd/commit/07a193d4dc8e4419f47fe21a45ef53fced8f9656) commit
If no RSM option is specified in `getItems` a empty rsm tag is sent, which according to the spec does not seem to make any sense, a "internal-database-error" is thrown, which does not give any clue on where the problem lies.
I thought of 50 as a reasonable big enough number, but this is debatable.
It could also be an option to just leave out the rsm tag as a fix, when no options are specified in `getItems`.
[Issue in ejabberd](https://github.com/processone/ejabberd/issues/2014).
