### PR TITLE
Fix typo in urn:xmpp:jingle:transports:dtls-sctp:1

### DIFF
--- a/lib/plugins/jingle.js
+++ b/lib/plugins/jingle.js
@@ -27,7 +27,7 @@ module.exports = function (client) {
             'urn:xmpp:jingle:apps:grouping:0',
             'urn:xmpp:jingle:apps:file-transfer:3',
             'urn:xmpp:jingle:transports:ice-udp:1',
-            'urn:xmpp:jingle:transports.dtls-sctp:1',
+            'urn:xmpp:jingle:transports:dtls-sctp:1',
             'urn:ietf:rfc:3264',
             'urn:ietf:rfc:5576',
             'urn:ietf:rfc:5888'


### PR DESCRIPTION
There was a period instead of a colon in the urn:xmpp:jingle:transports:dtls-sctp:1 feature string