### PR TITLE
MAM2 support

### DIFF
--- a/lib/plugins/mam.js
+++ b/lib/plugins/mam.js
@@ -28,7 +28,7 @@ function timeoutPromise(targetPromise, queryid, delay) {
 
 module.exports = function (client) {
 
-    client.disco.addFeature('urn:xmpp:mam:0');
+    client.disco.addFeature('urn:xmpp:mam:2');
 
     client.getHistorySearchForm = function (jid, cb) {
         return client.sendIq({
@@ -64,7 +64,7 @@ module.exports = function (client) {
                     val = val.toISOString();
                 }
                 if (name === 'FORM_TYPE') {
-                    val = 'urn:xmpp:mam:0';
+                    val = 'urn:xmpp:mam:2';
                 }
 
                 var existing = false;
@@ -103,16 +103,6 @@ module.exports = function (client) {
             results.push(msg.mamItem);
         });
 
-        var collectResults = new Promise(function (resolve) {
-            self.once('mam:result:' + queryid, 'session', function (msg) {
-                if (!allowed[msg.from.full]) {
-                    return;
-                }
-                msg.mamResult.items = results;
-                resolve(msg);
-            });
-        });
-
         var mamQuery = this.sendIq({
             type: 'set',
             to: to,
@@ -120,13 +110,9 @@ module.exports = function (client) {
             mam: opts
         });
 
-        timeoutPromise(Promise.all([
-            mamQuery,
-            collectResults
-        ]), queryid, (self.config.timeout * 1000) || 15000).then(function (results) {
-            var mamRes = results[1];
+        return timeoutPromise(mamQuery, queryid, (self.config.timeout * 1000) || 15000).then(function (mamRes) {
+            mamRes.mamResult.items = results;
             self.off('mam:item:' + queryid);
-            self.off('mam:result:' + queryid);
 
             if (cb) {
                 cb(null, mamRes);
@@ -134,7 +120,6 @@ module.exports = function (client) {
             return mamRes;
         }, function (err) {
             self.off('mam:item:' + queryid);
-            self.off('mam:result:' + queryid);
             if (cb) {
                 cb(err);
             } else {
@@ -159,10 +144,8 @@ module.exports = function (client) {
 
     client.on('message', function (msg) {
         if (msg.mamItem) {
+            client.emit('mam:item', msg);
             client.emit('mam:item:' + msg.mamItem.queryid, msg);
-        }
-        if (msg.mamResult) {
-            client.emit('mam:result:' + msg.mamResult.queryid, msg);
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "iana-hashes": "^1.0.2",
     "jingle": "^3.0.0",
     "jxt": "^3.0.1",
-    "jxt-xmpp": "^2.0.0",
+    "jxt-xmpp": "git+https://github.com/latentflip/jxt-xmpp#build",
     "jxt-xmpp-types": "^3.0.0",
     "lodash.assign": "^3.0.0",
     "lodash.filter": "^3.1.0",


### PR DESCRIPTION
Not sure if we're ready for this? Or if there's a way to support both mam:0 and mam:2 (I doubt it?) but we've been using this for a while and figured I should try and upstream.

Depends on https://github.com/otalk/jxt-xmpp/pull/21 (note the commit in this PR that points jxt-xmpp to a fork, which shall need to be removed before merging).