### PR TITLE
Improvements to the WebSocket transport for handling TLS endpoints employing SNI

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -246,6 +246,7 @@ When creating a client instance, the following settings will configure its behav
 - `sendReceipts` - boolean value to determine whether or not client automatically sends acknowledgements if they are requested (XEP-0184). Default value is true, set to false if you want to send acknowledgements yourself.
 - `transports` - a strings array of transport methods that may be used.
 - `wsURL` - URL for the XMPP over WebSocket connection endpoint.
+- `wsOptions` - additional options passed to WebSocket constructor (optional and not supported by all WebSocket clients)
 - `boshURL` - URL for the BOSH connection endpoint.
 - `sasl` - a list of the SASL mechanisms that are acceptable for use by the client.
 - `useStreamManagement` - set to `true` to enable resuming the session after a disconnect.

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -93,7 +93,7 @@ WSConnection.prototype.connect = function (opts) {
     self.hasStream = false;
     self.closing = false;
 
-    self.conn = new WS(opts.wsURL, 'xmpp');
+    self.conn = new WS(opts.wsURL, 'xmpp', opts.wsOptions);
     self.conn.onerror = function (e) {
         e.preventDefault();
         self.emit('disconnected', self);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "alt-sasl-digest-md5": "^1.0.0",
     "async": "^2.5.0",
     "browserify-versionify": "^1.0.4",
-    "faye-websocket": "^0.10.0",
+    "faye-websocket": "^0.11.0",
     "hostmeta": "^2.0.0",
     "iana-hashes": "^1.0.2",
     "jingle": "^3.0.0",


### PR DESCRIPTION
RE: https://github.com/legastero/stanza.io/issues/242

There are two commits here:

The first allows passing a `wsOptions` parameter to the constructor, which in turn will be passed to the constructor for the WebSocket transport.  For faye-websocket-node, this enables specifying the SNI server name via a `tls` parameter.

The second bumps the faye-websocket dependency from 0.10 to 0.11.  The faye-websocket 0.11 release included a change to set the server name parameter by default, so the explicit use of this `wsOptions` parameter should not be necessary for the most common use case.

Without one of these commits or the other, it is not possible to use stanza.io in a node.js XMPP client using the WebSocket transport with a TLS front-end that depends on SNI.  This includes Amazon's Application Load Balancer (ALB), which depends upon SNI for routing TLS connections based on hostname.