### PR TITLE
Fix Uncaught error on timeout (bosh)

### DIFF
--- a/lib/transports/bosh.js
+++ b/lib/transports/bosh.js
@@ -244,36 +244,33 @@ BOSHConnection.prototype.request = function (bosh) {
         method: 'POST',
         strictSSL: true,
         headers: {
-            'Content-Type': 'text/xml'
+          'Content-Type': 'text/xml'
         }
-    }, self.config.wait * 1.5, this.config.maxRetries).catch(function (err) {
-        self.hasStream = false;
-        var serr = new self.stanzas.StreamError({
-            condition: 'connection-timeout'
+      },self.config.wait * 1.5, this.config.maxRetries
+    ).then(function (body) {
+      self.emit('raw:incoming', new Buffer(body, 'utf8').toString());
+    }).then(function () {
+      self.requests = filter(self.requests, function (item) {
+        return item.id !== ticket.id;
+      });
+      // do not (re)start long polling if terminating, or request is pending, or before authentication
+      if (bosh.type !== 'terminate' && !self.requests.length && self.authenticated) {
+        // Delay next auto-request by two ticks since we're likely
+        // to send data anyway next tick.
+        process.nextTick(function () {
+          process.nextTick(self.longPoll.bind(self));
         });
-        self.emit('stream:error', serr, err);
-        self.disconnect();
+      }
+    }).catch(function (err) {
+      self.hasStream = false;
+      var serr = new self.stanzas.StreamError({
+        condition: 'connection-timeout'
+      });
+      self.emit('stream:error', serr, err);
+      self.disconnect();
     });
-
     ticket.request = req;
-
-    req.then(function (body) {
-        self.emit('raw:incoming', new Buffer(body, 'utf8').toString());
-    });
-
-    return req.then(function () {
-        self.requests = filter(self.requests, function (item) {
-            return item.id !== ticket.id;
-        });
-        // do not (re)start long polling if terminating, or request is pending, or before authentication
-        if (bosh.type !== 'terminate' && !self.requests.length && self.authenticated) {
-            // Delay next auto-request by two ticks since we're likely
-            // to send data anyway next tick.
-            process.nextTick(function () {
-                process.nextTick(self.longPoll.bind(self));
-            });
-        }
-    });
+    return req;
 };
 
 module.exports = BOSHConnection;


### PR DESCRIPTION
Fixes #262 

I had to chain the promises correctly so that the error is always caught. There was no need to emit a new event as the existing `stream:error` is sufficient :man_dancing: 