### PR TITLE
feat(push): add support for XEP-0357: Push Notifications

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -75,6 +75,9 @@
             - [`client.getHistoryPreferences([cb])`](#clientgethistorypreferencescb)
             - [`client.setHistoryPreferences(opts, [cb])`](#clientsethistorypreferencesopts-cb)
             - [`client.searchHistory(opts, [cb])`](#clientsearchhistoryopts-cb)
+        - [Push Notifications](#push-notifications)
+            - [`client.enableNotifications(jid, node, fieldList, [cb])`](#clientenablenotifications)
+            - [`client.disableNotifications(jid, node, [cb])`](#clientdisablenotifications)
         - [Other](#other)
             - [`client.deleteAccount([jid, cb])`](#clientdeleteaccountjid-cb)
             - [`client.getAccountInfo([jid, cb])`](#clientgetaccountinfojid-cb)
@@ -420,6 +423,29 @@ client.searchHistory({
             rsm: {max: 50, before: true},  --
             complete: false
         }
+```
+#### Push Notifications
+##### `client.enableNotifications(jid, node, fieldList, [cb])`
+Enable push notifications for the given `node` in the given push
+server (`jid`).  `fieldList` is an array of objects with `name` and
+`value` properties to be passed as form's fields to the outgoing `iq`
+stanza.
+
+Example:
+```js
+client.enableNotifications('push.example.im',
+                           'e4109a84-89aa-11e8-9373-431c37c82976',
+						   [{name: 'secret', value: 's3cr3t'}]);
+```
+
+##### `client.disableNotifications(jid, node, [cb])`
+Disable push notifications from the given push server (`jid`).  If
+`node` is provided, only unsubscribes from notifications from such
+node.
+
+Example:
+```js
+client.disableNotifications('push.example.im', 'e4109a84-89aa-11e8-9373-431c37c82976')
 ```
 #### Avatars
 ##### `client.getAvatar(jid, id, [cb])`

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -36,6 +36,7 @@ module.exports = function (client) {
     client.use(require('./ping'));
     client.use(require('./private'));
     client.use(require('./psa'));
+    client.use(require('./push'));
     client.use(require('./pubsub'));
     client.use(require('./reach'));
     client.use(require('./receipts'));

--- a/lib/plugins/push.js
+++ b/lib/plugins/push.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = function (client) {
+
+	client.disco.addFeature('urn:xmpp:push:0');
+
+	client.enableNotifications = function(jid, node, fieldList, cb) {
+		var fields = [{
+			name: 'FORM_TYPE',
+			value: 'http://jabber.org/protocol/pubsub#publish-options'
+		}];
+		var iq = {
+			type: 'set',
+			enablePush: {
+				jid: jid,
+				node: node,
+			}
+		};
+		if (fieldList.length) {
+			iq.enablePush.form = {
+				fields: fields.concat(fieldList)
+			};
+		}
+		return this.sendIq(iq, cb);
+	};
+
+	client.disableNotifications = function(jid, node, cb) {
+		var iq = {
+			type: 'set',
+			disablePush: {
+				jid: jid
+			}
+		};
+		if (node) {
+			iq.disablePush.node = node;
+		}
+		return this.sendIq(iq, cb);
+	};
+};

--- a/lib/plugins/push.js
+++ b/lib/plugins/push.js
@@ -16,7 +16,7 @@ module.exports = function (client) {
 				node: node,
 			}
 		};
-		if (fieldList.length) {
+		if (fieldList && fieldList.length) {
 			iq.enablePush.form = {
 				fields: fields.concat(fieldList)
 			};


### PR DESCRIPTION
Add two new functions to `client`: `enableNotifications` and
`disableNotifications` for clients to send the required stanzas for
enabling and disabling push notifications.