### PR TITLE
refactor: emit full message on Chat Markers events

### DIFF
--- a/src/plugins/markers.js
+++ b/src/plugins/markers.js
@@ -17,15 +17,15 @@ export default function(client) {
         }
 
         if (msg.received) {
-            return client.emit('marker:received', msg.received);
+            return client.emit('marker:received', msg);
         }
 
         if (msg.displayed) {
-            return client.emit('marker:displayed', msg.displayed);
+            return client.emit('marker:displayed', msg);
         }
 
         if (msg.acknowledged) {
-            return client.emit('marker:acknowledged', msg.acknowledged);
+            return client.emit('marker:acknowledged', msg);
         }
     });
 


### PR DESCRIPTION
We found out that emitting only the message ID forces the application to do messages' lookup actions that can be avoided by emitting the full msg on chat marker events, simplifying `stanza.io` users' code.

What do you think of this change?

BREAKING CHANGE: full object now emitted instead of a plain message ID