### PR TITLE
Change muc:affiliation event name to muc:other and include the "to" field

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -147,7 +147,6 @@
     -   [`message:error`](#messageerror)
     -   [`message:sent`](#messagesent)
     -   [`message`](#message)
-    -   [`muc:affiliation`](#mucaffiliation)
     -   [`muc:available`](#mucavailable)
     -   [`muc:declined`](#mucdeclined)
     -   [`muc:destroyed`](#mucdestroyed)
@@ -155,6 +154,7 @@
     -   [`muc:invite`](#mucinvite)
     -   [`muc:join`](#mucjoin)
     -   [`muc:leave`](#mucleave)
+    -   [`muc:other`](#mucother)
     -   [`muc:subject`](#mucsubject)
     -   [`muc:unavailable`](#mucunavailable)
     -   [`nick`](#nick)
@@ -749,8 +749,6 @@ client.on('message', message => {
 
 ### muc:available
 
-### muc:affiliation
-
 ### muc:declined
 
 ### muc:error
@@ -762,6 +760,8 @@ client.on('message', message => {
 ### muc:leave
 
 ### muc:subject
+
+### muc:other
 
 ### muc:unavailable
 

--- a/src/plugins/muc.js
+++ b/src/plugins/muc.js
@@ -45,9 +45,10 @@ export default function(client) {
                     room: msg.from
                 });
             } else {
-                client.emit('muc:affiliation', {
+                client.emit('muc:other', {
                     muc: msg.muc,
-                    room: msg.from
+                    room: msg.from,
+                    to: msg.to
                 });
             }
         } else if (msg.mucInvite) {


### PR DESCRIPTION
The name was a bit misguiding as some events had nothing to do with changes in
muc affiliation. New name makes reference of other muc related events that are
not included in a specific element. Some example of possible events are:

```
{
  "muc": {
    "codes": [
      "104",
      "170",
      "172"
    ]
  },
  "room": "f2c06530-1831-11e9-a5f0-b7c86edf572e@conference.example.com",
  "to": "alice@example.com/VopfXx38"
}
```

```
{
  "muc": {
    "actor": {
      "jid": ""
    },
    "affiliation": "member",
    "jid": "bob@example.com",
    "reason": "Invited by alice@example.com/VopfXx38"
  },
  "room": "f2c06530-1831-11e9-a5f0-b7c86edf572e@conference.example.com",
  "to": "alice@example.com/VopfXx38"
}
```