### PR TITLE
Fix: Push Notifcation, type field to form while enabling

### DIFF
--- a/src/plugins/push.js
+++ b/src/plugins/push.js
@@ -19,7 +19,8 @@ export default function(client) {
         };
         if (fieldList && fieldList.length) {
             iq.enablePush.form = {
-                fields: fields.concat(fieldList)
+                fields: fields.concat(fieldList),
+                type: 'submit'
             };
         }
         return this.sendIq(iq, cb);


### PR DESCRIPTION
I encountered a problem using the push notifications feature with an ejabberd server.

### Before:
The client was sending:
```xml
<iq xmlns="jabber:client" type="set" id="30084eb7-52a6-4862-ac8f-c4893dd51597">
    <enable xmlns="urn:xmpp:push:0" jid="client-1@push.localhost" node="test-42">
        <x xmlns="jabber:x:data">
            <field var="FORM_TYPE"><value>http://jabber.org/protocol/pubsub#publish-options</value></field>
            <field var="custom-field"><value>custom-value</value></field>
        </x>
    </enable>
</iq>
```

The ejabberd server was replying:
```xml
<iq xmlns="jabber:client" xml:lang="en" to="test@localhost/chrome-stanza-04" from="test@localhost" type="error" id="30084eb7-52a6-4862-ac8f-c4893dd51597">
    ...
    <error code="400" type="modify">
        <bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" />
        <text xml:lang="en" xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">Missing attribute 'type' in tag &lt;x/&gt; qualified by namespace 'jabber:x:data'</text>
    </error>
</iq>
```

### Now:
The client is sending:
```xml
<iq xmlns="jabber:client" type="set" id="30084eb7-52a6-4862-ac8f-c4893dd51597">
    <enable xmlns="urn:xmpp:push:0" jid="client-1@push.localhost" node="test-42">
        <x xmlns="jabber:x:data" type="submit">
            <field var="FORM_TYPE"><value>http://jabber.org/protocol/pubsub#publish-options</value></field>
            <field var="custom-field"><value>custom-value</value></field>
        </x>
    </enable>
</iq>
```

The type must be `submit` according to [xmpp documentation](https://xmpp.org/extensions/xep-0357.html#enabling):  
```xml
<iq type='set' id='x43'>
  <enable xmlns='urn:xmpp:push:0' jid='push-5.client.example' node='yxs32uqsflafdk3iuqo'>
    <x xmlns='jabber:x:data' type='submit'>
      <field var='FORM_TYPE'><value>http://jabber.org/protocol/pubsub#publish-options</value></field>
      <field var='secret'><value>eruio234vzxc2kla-91</value></field>
    </x>
  </enable>
</iq>
```