### PR TITLE
improve chat markers

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -172,7 +172,7 @@ export default class Client extends WildEmitter {
         });
 
         this.on('message', msg => {
-            if (Object.keys(msg.$body || {}).length) {
+            if (Object.keys(msg.$body || {}).length && !msg.received && !msg.displayed) {
                 if (msg.type === 'chat' || msg.type === 'normal') {
                     this.emit('chat', msg);
                 } else if (msg.type === 'groupchat') {

--- a/src/plugins/markers.js
+++ b/src/plugins/markers.js
@@ -1,3 +1,4 @@
+import { JID } from '../protocol/jid';
 import { Namespaces } from '../protocol';
 
 export default function(client) {
@@ -9,10 +10,7 @@ export default function(client) {
 
     client.on('message', function(msg) {
         if (enabled(msg)) {
-            client.sendMessage({
-                received: msg.id,
-                to: msg.from
-            });
+            client.markReceived(msg);
             return;
         }
 
@@ -29,20 +27,38 @@ export default function(client) {
         }
     });
 
+    client.markReceived = function(msg) {
+        if (enabled(msg)) {
+            const to = msg.type === 'groupchat' ? new JID(msg.from.bare) : msg.from;
+            client.sendMessage({
+                body: '',
+                received: msg.id,
+                to,
+                type: msg.type
+            });
+        }
+    };
+
     client.markDisplayed = function(msg) {
         if (enabled(msg)) {
+            const to = msg.type === 'groupchat' ? new JID(msg.from.bare) : msg.from;
             client.sendMessage({
+                body: '',
                 displayed: msg.id,
-                to: msg.from
+                to,
+                type: msg.type
             });
         }
     };
 
     client.markAcknowledged = function(msg) {
         if (enabled(msg)) {
+            const to = msg.type === 'groupchat' ? new JID(msg.from.bare) : msg.from;
             client.sendMessage({
                 acknowledged: msg.id,
-                to: msg.from
+                body: '',
+                to,
+                type: msg.type
             });
         }
     };


### PR DESCRIPTION
- Export method to mark a message as received. This is needed because messages are not always marked as received automatically (e.g.: when retrieving older messages in a muc).
- Send mark messages with type chat/groupchat and include an empty body in them to force MAM to archive them.
- Don't emit chat/groupchat event when the message includes a received or displayed mark.