### PR TITLE
fix problem with message processing hints

### DIFF
--- a/src/protocol/stanzas/hints.js
+++ b/src/protocol/stanzas/hints.js
@@ -40,7 +40,7 @@ export default function(JXT) {
             set: function(hints) {
                 for (let i = 0, len = this.xml.childNodes.length; i < len; i++) {
                     const child = this.xml.childNodes[i];
-                    if (child.namespaceURI !== NS.HINTS) {
+                    if (child.namespaceURI === NS.HINTS) {
                         this.xml.removeChild(this.xml.childNodes[i]);
                     }
                 }


### PR DESCRIPTION
Current code removes every child of a different namespace while if I'm not wrong the expected behaviour is removing current children of the message processing hints namespace.