### PR TITLE
Add pollyfill to avoid [regeneratorRuntime is not defined] in browser js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
         "ws": "^6.1.2"
     },
     "devDependencies": {
+        "@babel/core": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "babel-loader": "^8.0.5",
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-stage-0": "^6.24.1",
         "husky": "^1.1.3",
         "mkdirp": "^0.5.1",
         "prettier": "^1.14.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const Pkg = require('./package.json');
 
 module.exports = {
-    entry: './dist/npm/module.js',
+    entry: ['babel-polyfill', './dist/npm/module.js'],
 
     output: {
         filename: 'stanza.browser.js',
@@ -24,8 +24,11 @@ module.exports = {
             },
             {
                 exclude: /node_modules/,
-                loader: 'ts-loader',
-                test: /\.m?[jt]s$/
+                loader: 'babel-loader',
+                test: /\.m?[jt]s$/,
+                options: {
+                    presets: ['@babel/preset-env']
+                }
             }
         ]
     },


### PR DESCRIPTION
The version of [ stanza.browser.js ] runs in browser will throw [ regeneratorRuntime is not defined ] exception.

The PR add babel to support the polyfill to support aysnc generator feature.

Thanks.
 