### PR TITLE
Stop transpiling to CJS modules before webpack bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
         "string-replace-loader": "^2.1.1",
         "tap-spec": "^5.0.0",
         "tape": "^4.8.0",
-        "ts-loader": "^5.3.0",
         "ts-node": "^8.0.3",
         "tslint": "^5.11.0",
         "typescript": "^3.1.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,11 +21,6 @@ module.exports = {
                     search: '__STANZAIO_VERSION__'
                 },
                 test: /index\.[jt]s/
-            },
-            {
-                exclude: /node_modules/,
-                loader: 'ts-loader',
-                test: /\.m?[jt]s$/
             }
         ]
     },


### PR DESCRIPTION
Webpack bundling entry point path is already compiled by typescript and then bundled by rollup. Using typescript with existing configuration is transforming esm to cjs preventing tree shaking to occur while bundling the dependencies.