### PR TITLE
Surface websocket close event

### DIFF
--- a/src/transports/websocket.js
+++ b/src/transports/websocket.js
@@ -83,8 +83,8 @@ export default class WSConnection extends WildEmitter {
             }
             self.emit('disconnected', self);
         };
-        self.conn.onclose = function() {
-            self.emit('disconnected', self);
+        self.conn.onclose = function(e) {
+            self.emit('disconnected', self, e);
         };
         self.conn.onopen = function() {
             self.sm.started = false;


### PR DESCRIPTION
Surface the websocket close event in the disconnect so that the consuming application can change behavior. E.g., authentication, cxfr, server error all might dictate different reconnect behaviors