### PR TITLE
fix(browser): avoid global in stream polyfills

### DIFF
--- a/src/platform/browser/stream/lib/_stream_readable.js
+++ b/src/platform/browser/stream/lib/_stream_readable.js
@@ -49,7 +49,7 @@ var Stream = require('events').EventEmitter;
 /*<replacement>*/
 
 var Buffer = require('../../buffer').Buffer;
-var OurUint8Array = global.Uint8Array || function () {};
+var OurUint8Array = typeof Uint8Array !== 'undefined' ? Uint8Array : function () {};
 function _uint8ArrayToBuffer(chunk) {
     return Buffer.from(chunk);
 }

--- a/src/platform/browser/stream/lib/_stream_writable.js
+++ b/src/platform/browser/stream/lib/_stream_writable.js
@@ -74,7 +74,7 @@ var Stream = require('events').EventEmitter;
 /*<replacement>*/
 
 var Buffer = require('../../buffer').Buffer;
-var OurUint8Array = global.Uint8Array || function () {};
+var OurUint8Array = typeof Uint8Array !== 'undefined' ? Uint8Array : function () {};
 function _uint8ArrayToBuffer(chunk) {
     return Buffer.from(chunk);
 }


### PR DESCRIPTION
## Summary
Avoid bare `global` access in the browser stream polyfills so the browser build works in modern module-worker environments that do not inject a Node-style global.

## Changes
- replace `global.Uint8Array || function () {}` with a browser-safe `Uint8Array` check in the browser readable stream polyfill
- replace `global.Uint8Array || function () {}` with a browser-safe `Uint8Array` check in the browser writable stream polyfill

## Why
The browser platform path uses these vendored stream polyfills at runtime via the transport/parser stack, so the bare `global` reference can cause `ReferenceError: global is not defined` in browser worker setups.

## Verification
- `npm run build`
- `npm test`